### PR TITLE
Simc-codes: Added code for Q45-Composite Factors

### DIFF
--- a/simc-codes/q45.simc
+++ b/simc-codes/q45.simc
@@ -1,0 +1,23 @@
+//To find composite factors of a number
+MAIN
+    //Take input of the number whose factors are to be calculated
+    var n = input("Input number : ", "i")
+    print("Composite Factors of {n} are:")
+    var i = 1
+    var p = 1
+    while(i <= n){
+	if (n % i == 0){
+	    var j = 2
+	    while (j < i) {
+		if (i%j == 0){
+		    p=0
+		}
+	    j++
+	    }
+	    if(p == 0){
+		print(" {i}")
+	    }
+	}
+    i++
+    }
+END_MAIN


### PR DESCRIPTION
Added Simc code for finding all the composite factors of the given
number. The algorithm is basic as it finds all the factors of the number
and checks if any factors are prime, only prints non-prime, i.e.
composite factors.
closes #92

Signed-off-by: Puranjay Mohan <puranjay12@gmail.com>