### PR TITLE
Change lexical analyzer to identify 'or' and 'and' tokens

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -419,15 +419,15 @@ def lexical_analyze(filename, table):
         elif source_code[i] == "&":
             if source_code[i+1] == "&":
                 tokens.append(Token("and", "", line_num))
-            elif source_code[i-1] != "&":
+                i += 2
+            else:
                 tokens.append(Token("address_of", "", line_num))
-            i += 1
+                i += 1
 
         # Identifying 'or' token
         elif source_code[i] == "|":
-            if source_code[i+1] == "|":
-                tokens.append(Token("or", "", line_num))
-            i +=1
+            tokens.append(Token("or", "", line_num))
+            i += 2
 
         # Identifying divide_equal or divide token
         elif source_code[i] == "/":

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -415,10 +415,19 @@ def lexical_analyze(filename, table):
             tokens.append(Token("power", "", line_num))
             i += 1
 
-        # Identifying 'address of' token
+        # Identifying 'address of' or 'and' token
         elif source_code[i] == "&":
-            tokens.append(Token("address_of", "", line_num))
+            if source_code[i+1] == "&" and source_code[i-1] != "&":
+                tokens.append(Token("and", "", line_num))
+            elif source_code[i+1] != "&" and source_code[i-1] != "&":
+                tokens.append(Token("address_of", "", line_num))
             i += 1
+
+        # Identifying 'or' token
+        elif source_code[i] == "|":
+            if source_code[i+1] == "|" and source_code[i-1] != "|":
+                tokens.append(Token("or", "", line_num))
+            i +=1
 
         # Identifying divide_equal or divide token
         elif source_code[i] == "/":

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -417,15 +417,15 @@ def lexical_analyze(filename, table):
 
         # Identifying 'address of' or 'and' token
         elif source_code[i] == "&":
-            if source_code[i+1] == "&" and source_code[i-1] != "&":
+            if source_code[i+1] == "&":
                 tokens.append(Token("and", "", line_num))
-            elif source_code[i+1] != "&" and source_code[i-1] != "&":
+            elif source_code[i-1] != "&":
                 tokens.append(Token("address_of", "", line_num))
             i += 1
 
         # Identifying 'or' token
         elif source_code[i] == "|":
-            if source_code[i+1] == "|" and source_code[i-1] != "|":
+            if source_code[i+1] == "|":
                 tokens.append(Token("or", "", line_num))
             i +=1
 


### PR DESCRIPTION
Changed lexical analyser to correctly identify 'and' and 'or' tokens.

The double-symbols `&&` and `||` are assimilated to one token ('and' and 'or' respectively) and the line
```
if (p >= 0 || q >= 0) {
```

now gives

```
Token('if', '', '10')
Token('left_paren', '', '10')
Token('id', '1', '10')
Token('greater_than_equal', '', '10')
Token('number', '7', '10')
Token('or', '', '10')
Token('id', '4', '10')
Token('greater_than_equal', '', '10')
Token('number', '8', '10')
Token('right_paren', '', '10')
Token('call_end', '', '10')
Token('left_brace', '', '10')
```
The identification of the symbol "&" was also changed in order to differentiate between an "and" token and an "address_of" token.
Fixes #189 