### PR TITLE
Support for default arguments in functions, resolves cimplex/sim-c#34, resolves cimplex/sim-c#204

### DIFF
--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -308,6 +308,17 @@ def function_parameters(
     i           (int)   = Current index in list of tokens
 
     """
+    if tokens[i].type == "right_paren":
+
+        i += 1
+
+        check_if(tokens[i].type,
+                 "call_end",
+                 "End of call expected",
+                 tokens[i].line_num)
+
+        return [], i
+
     parameters = []
     default_val_required = False
 
@@ -345,6 +356,10 @@ def function_parameters(
                  "call_end",
                  "End of call expected",
                  tokens[i].line_num)
+
+    else:
+        error("Function parameters must be identifiers",
+              tokens[i].line_num)
 
     return parameters, i
 

--- a/test/data/add.simc
+++ b/test/data/add.simc
@@ -1,0 +1,3 @@
+fun add(x, y) {
+    return x + y
+}

--- a/test/data/add_err.simc
+++ b/test/data/add_err.simc
@@ -1,0 +1,3 @@
+fun add(1, y) {
+    return y
+}

--- a/test/data/add_w_default.simc
+++ b/test/data/add_w_default.simc
@@ -1,0 +1,11 @@
+fun add(x = 1, y = 2) {
+    return x + y
+}
+
+MAIN
+
+    var a = add(3, 4)
+    var b = add(3)
+    var c = add()
+
+END_MAIN

--- a/test/test_simc_parser.py
+++ b/test/test_simc_parser.py
@@ -1,0 +1,37 @@
+import unittest
+import sys
+
+sys.path.append("..")
+
+from simc.lexical_analyzer import lexical_analyze
+from simc.symbol_table import SymbolTable
+from simc.simc_parser import *
+
+
+class TestSimcParser(unittest.TestCase):
+
+    def test_function_definition(self):
+
+        symbol_table = SymbolTable()
+        tokens = lexical_analyze("data/add.simc", symbol_table)
+
+        opcodes = parse(tokens, symbol_table)
+
+        self.assertTrue(opcodes)
+
+    def test_function_definition_w_default(self):
+
+        symbol_table = SymbolTable()
+        tokens = lexical_analyze("data/add_w_default.simc", symbol_table)
+
+        opcodes = parse(tokens, symbol_table)
+
+        self.assertTrue(opcodes)
+
+    def test_function_definition_w_error(self):
+
+        symbol_table = SymbolTable()
+        tokens = lexical_analyze("data/add_err.simc", symbol_table)
+
+        with self.assertRaises(SystemExit):
+            parse(tokens, symbol_table)


### PR DESCRIPTION
This PR adds functionality to parse default argument values (only number and string literals are supported). The default argument values are added to the functions typedata in the symbol table and later used while parsing a function call to add the missing parameters.
Unit tests for the functionality are provided.