### PR TITLE
Issue 27: allow single line block statements withou {}

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -314,6 +314,9 @@ def lexical_analyze(filename, table):
     # Parantheses checker for detecting function call
     parantheses_count = 0
 
+    # Indicate start of expression
+    expression_active = False
+    
     # To store comment string
     comment_str = ""
 
@@ -358,9 +361,9 @@ def lexical_analyze(filename, table):
             tokens.append(token)
 
         # Identifying left paren token
+
         elif source_code[i] == "(":
-            if tokens[-1].type == "id" or parantheses_count > 0:
-                parantheses_count += 1
+            parantheses_count += 1
             tokens.append(Token("left_paren", "", line_num))
             i += 1
 
@@ -368,13 +371,21 @@ def lexical_analyze(filename, table):
         elif source_code[i] == ")":
             if parantheses_count > 0:
                 parantheses_count -= 1
-
-            tokens.append(Token("right_paren", "", line_num))
-
-            if parantheses_count == 0:
-                tokens.append(Token("call_end", "", line_num))
+                tokens.append(Token("right_paren", "", line_num))
+            else:
+               error("Parentheses does not match.", line_num);
 
             i += 1
+        # Identifying end of expression
+        elif source_code[i] == "\n":
+            # tokens.append(Token("right_paren", "", line_num))
+            if parantheses_count == 0:
+                tokens.append(Token("call_end", "", line_num))
+            else:
+                error("Parentheses does not match.", line_num);
+
+            i += 1
+            line_num += 1
 
         # Identifying left brace token
         elif source_code[i] == "{":

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -77,7 +77,7 @@ def check_if_statment(tokens, brace_used, i):
 
     if(found_code >= 2):
         error("Expected only one instructions before 'else'", tokens[i].line_num);
-        
+
 
 def function_call_statement(tokens, i, table, func_ret_type):
     """
@@ -920,7 +920,8 @@ def if_statement(tokens, i, table, func_ret_type):
     Returns
     =======
     OpCode, int: The opcode for the assign code and the index after parsing if statement
-
+    brace_used, boolean: Indicate if brace was used
+    
     Grammar
     =======
     if_statement -> if(condition) { body }
@@ -967,20 +968,19 @@ def if_statement(tokens, i, table, func_ret_type):
     # Check if { follows ) in if statement
     ret_idx = 0
     brace_used = True
-
-    if(query_check_if(
-        tokens[i + 1].type,
-        "left_brace",
-        "Expected { before if body",
-        tokens[i + 1].line_num,
-    )):
+    if(tokens[i + 1].type == "left_brace"):
         # Loop until } is reached
         i += 2
         ret_idx = i
         found_right_brace = False
         while i < len(tokens) and tokens[i].type != "right_brace":
+            # If there a else before right brace, the sintax is not right
+            if(tokens[i].type in ["else", "left_brace"]):
+                break
+
             if found_right_brace:
                 found_right_brace = True
+                break
             i += 1
 
         # If right brace found at end

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -25,29 +25,7 @@ def check_if(given_type, should_be_types, msg, line_num):
     if given_type not in should_be_types:
         error(msg, line_num)
 
-
-def query_check_if(given_type, should_be_types, msg, line_num):
-    """
-    Check if type matches what it should be, then return true otherwise return false
-
-    Params
-    ======
-    given_type      (string)      = Type of token to be checked
-    should_be_types (string/list) = Type(s) to be compared with
-    msg             (string)      = Error message to print in case some case fails
-    line_num        (int)         = Line number
-    """
-
-    # Convert to list if type is string
-    if type(should_be_types) == str:
-        should_be_types = [should_be_types]
-
-    # If the given_type is not part of should_be_types then throw error and exit
-    if given_type not in should_be_types:
-        return False;
-    return True;
-
-
+        
 def check_if_statment(tokens, brace_used, i):
     """
         Check if there is only one instruction before a if without braces otherwise throw an error and exit


### PR DESCRIPTION
Resolve  #27 

## Cases tested:
-------------------------------------  Case 1 -----------------------------------------------------------------------
sim-c: 
```

  var i = 0
  if(i % 2 == 0)
    print("Even")
  else
    print("Odd")
```

Output: c code
```
int i = 0;
if(i % 2 == 0) 	printf("Even");
else 	printf("Odd");
```

-------------------------------------  Case 2 -----------------------------------------------------------------------
simc:
```
  var i = 0
  if(i % 2 == 0)
    print("Even")
    print("Even")
  else
    print("Odd")
```
Output: throw error
`[Line 3] Error: Expected only one instructions before 'else'
`
</br>
-------------------------------------  Case 3 -----------------------------------------------------------------------
simc:
```
  var i = 0
  if(i % 2 == 0)
  else
    print("Odd")
```

Output: throw error
`[Line 4] Error: error: expected primary-expression before ‘else’
</br>

-------------------------------------  Case 4 -----------------------------------------------------------------------
simc:
```
  var i = 0
  if(i % 2 == 0) {
      print("Even")
      print("You won!")
  } else
    print("Odd")

```
Output: c
```
int i = 0;
if(i % 2 == 0) {
printf("Even");
printf("You won!");
}
else 	printf("Odd");
```
`
-------------------------------------  Case 5 -----------------------------------------------------------------------
simc:
```
  var i = 0
  if(i % 2 == 0) {
    print("Even")
    print("You won!")
  else {
    print("Odd")
  }
```
Output: throw error
`[Line 6] Error: Expected } after if body`
</br>

-------------------------------------  Case 6 -----------------------------------------------------------------------
simc:
```
  var i = 0
  if(i % 2 == 0) {
    var j = 0
  else {
    print("Odd")
  }
```
Output: throw error
`[Line 5] Error: Var can not be declared in this scope