### PR TITLE
Issues 26, 190:  Evalution of expression in parentheses changed, bugs solved

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -313,9 +313,6 @@ def lexical_analyze(filename, table):
 
     # Parantheses checker for detecting function call
     parantheses_count = 0
-
-    # Indicate start of expression
-    expression_active = False
     
     # To store comment string
     comment_str = ""

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -314,6 +314,9 @@ def lexical_analyze(filename, table):
     # Parantheses checker for detecting function call
     parantheses_count = 0
 
+    # Indicate start of expression
+    expression_active = False
+    
     # To store comment string
     comment_str = ""
 
@@ -358,9 +361,9 @@ def lexical_analyze(filename, table):
             tokens.append(token)
 
         # Identifying left paren token
+
         elif source_code[i] == "(":
-            if tokens[-1].type == "id" or parantheses_count > 0:
-                parantheses_count += 1
+            parantheses_count += 1
             tokens.append(Token("left_paren", "", line_num))
             i += 1
 
@@ -368,13 +371,21 @@ def lexical_analyze(filename, table):
         elif source_code[i] == ")":
             if parantheses_count > 0:
                 parantheses_count -= 1
-
-            tokens.append(Token("right_paren", "", line_num))
-
-            if parantheses_count == 0:
-                tokens.append(Token("call_end", "", line_num))
+                tokens.append(Token("right_paren", "", line_num))
+            else:
+               error("Parentheses does not match.", line_num);
 
             i += 1
+        # Identifying end of expression
+        elif source_code[i] == "\n":
+            # tokens.append(Token("right_paren", "", line_num))
+            if parantheses_count == 0:
+                tokens.append(Token("call_end", "", line_num))
+            else:
+                error("Parentheses does not match.", line_num);
+
+            i += 1
+            line_num += 1
 
         # Identifying left brace token
         elif source_code[i] == "{":

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -233,14 +233,6 @@ def function_definition_statement(tokens, i, table, func_ret_type):
 
     parameters, i = function_parameters(tokens, i + 2, table)
 
-    # Check if ) follows expression in function
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after function params list",
-        tokens[i - 1].line_num,
-    )
-
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
         i += 1
@@ -348,10 +340,6 @@ def function_parameters(
             else:
                 error("Parameter expected after comma", tokens[i].line_num)
 
-        check_if(tokens[i].type,
-                 "right_paren",
-                 "Right parentheses expected",
-                 tokens[i].line_num)
         i += 1
 
         check_if(tokens[i].type,
@@ -814,21 +802,13 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows ( in while statement
+    # check if expression follows "(expression)" in while statement
     op_value, _, i, func_ret_type = expression(
         tokens,
         i,
         table,
         "Expected expression inside while statement",
         func_ret_type=func_ret_type,
-    )
-
-    # check if ) follows expression in while statement
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after expression in while statement",
-        tokens[i - 1].line_num,
     )
 
     # If while is not part of do-while
@@ -903,7 +883,7 @@ def if_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows ( in if statement
+    # check if expression follows "(expression)" partner in if statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
         i,
@@ -912,13 +892,6 @@ def if_statement(tokens, i, table, func_ret_type):
         func_ret_type=func_ret_type,
     )
     op_value_list = op_value.replace(" ", "").split(",")
-    # check if ) follows expression in if statement
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after expression in if statement",
-        tokens[i - 1].line_num,
-    )
 
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
@@ -937,15 +910,6 @@ def if_statement(tokens, i, table, func_ret_type):
 
     # Loop until } is reached
     i += 1
-    ret_idx = i 
-    found_right_brace = False
-    while i < len(tokens) and tokens[i].type != "right_brace":
-        if found_right_brace:
-            found_right_brace = True
-        i += 1
-
-    # Loop until } is reached
-    i += 2
     ret_idx = i
     found_right_brace = False
     while i < len(tokens) and tokens[i].type != "right_brace":
@@ -972,13 +936,6 @@ def switch_statement(tokens, i, table, func_ret_type):
         table,
         "Expected expression inside switch statement",
         func_ret_type=func_ret_type,
-    )
-
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after expression in switch",
-        tokens[i - 1].line_num,
     )
 
     check_if(
@@ -1046,7 +1003,7 @@ def print_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # Check if expression follows ( in print statement
+    # Check if expression follows "(expression)" patner in print statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
         i,
@@ -1065,14 +1022,6 @@ def print_statement(tokens, i, table, func_ret_type):
         5: '"%lf", ',
     }
     op_value = prec_to_type[op_type] + op_value[1:-1]
-
-    # Check if print statement has closing )
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after expression in print statement",
-        tokens[i - 1].line_num,
-    )
 
     # Return the opcode and i+1 (the token after print statement)
     return OpCode("print", op_value), i + 1, func_ret_type
@@ -1418,7 +1367,7 @@ def exit_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows ( in exit statement
+    # check if expression follows "(expression)" partner in exit statement
     op_value, _, i, func_ret_type = expression(
         tokens,
         i,
@@ -1427,13 +1376,6 @@ def exit_statement(tokens, i, table, func_ret_type):
         func_ret_type=func_ret_type,
     )
     op_value_list = op_value.replace(" ", "").split(",")
-    # check if ) follows expression in exit statement
-    check_if(
-        tokens[i - 1].type,
-        "right_paren",
-        "Expected ) after expression in exit statement",
-        tokens[i - 1].line_num,
-    )
 
     return OpCode("exit", op_value[1:-1]), i, func_ret_type
 

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -8,7 +8,6 @@ from .op_code import OpCode
 def check_if(given_type, should_be_types, msg, line_num):
     """
     Check if type matches what it should be otherwise throw an error and exit
-
     Params
     ======
     given_type      (string)      = Type of token to be checked
@@ -29,18 +28,15 @@ def check_if(given_type, should_be_types, msg, line_num):
 def function_call_statement(tokens, i, table, func_ret_type):
     """
     Parse function calling statement
-
     Params
     ======
     tokens        (list)        = List of tokens
     i             (int)         = Current index in token
     table         (SymbolTable) = Symbol table constructed holding information about identifiers and constants
     func_ret_type (dict)        = If return type of function is not figured yet
-
     Returns
     =======
     OpCode, int, dict: The opcode for the assign code, index after parsing function calling statement and function return type
-
     Grammar
     =======
     function_call_statement   -> id([actual_params,]*)
@@ -144,12 +140,10 @@ def function_call_statement(tokens, i, table, func_ret_type):
 def extract_func_typedata(typedata, table):
     """
     Extract typedata of function
-
     Params
     ======
     typedata    (string)        = Typedata of function in format "function---param1---param2---...&&&default_val1&&&...
     table       (SymbolTable)   = Symbol table
-
     Returns
     =======
     parameters      (list)  = Parameter names
@@ -192,19 +186,16 @@ def fill_missing_args_with_defaults(
 def function_definition_statement(tokens, i, table, func_ret_type):
     """
     Parse function definition statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
     func_ret_type (string) = Function return type
-
     Returns
     =======
     OpCode, int, string: The opcode for the assign code, the index, and the name of the function after
                          parsing function calling statement
-
     Grammar
     =======
     function_definition_statement   -> fun id([formal_param,]*) { body }
@@ -232,6 +223,14 @@ def function_definition_statement(tokens, i, table, func_ret_type):
     )
 
     parameters, i = function_parameters(tokens, i + 2, table)
+
+    # Check if ) follows expression in function
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after function params list",
+        tokens[i - 1].line_num,
+    )
 
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
@@ -289,18 +288,15 @@ def function_parameters(
         table):
     """
     Parse function parameters
-
     Params
     ======
     tokens  (list)          = List of tokens
     i       (int)           = Current index in list of tokens
     table   (SymbolTable)   = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     parameters  (list)  = List of parameters (= list of (ids, default))
     i           (int)   = Current index in list of tokens
-
     """
     if tokens[i].type == "right_paren":
 
@@ -340,6 +336,10 @@ def function_parameters(
             else:
                 error("Parameter expected after comma", tokens[i].line_num)
 
+        check_if(tokens[i].type,
+                 "right_paren",
+                 "Right parentheses expected",
+                 tokens[i].line_num)
         i += 1
 
         check_if(tokens[i].type,
@@ -361,19 +361,16 @@ def function_parameter(
         default_val_required):
     """
     Parse function parameter
-
     Params
     ======
     tokens  (list)              = List of tokens
     i       (int)               = Current index in list of tokens
     table   (SymbolTable)       = Symbol table constructed holding information about identifiers and constants
     default_val_required (bool) = Default value is required
-
     Returns
     =======
     (parameter, default_val_id?)    (tuple?) = Parameter and optional default value id or none
     i                               (int)    = Current index in list of tokens
-
     """
     if tokens[i].type != "id":
         return None, i
@@ -419,7 +416,6 @@ def expression(
 ):
     """
     Parse and expression from tokens
-
     Params
     ======
     tokens                  (list)        = List of tokens
@@ -430,7 +426,6 @@ def expression(
     accept_empty_expression (bool)        = Accept empty expression or not
     expect_paren            (bool)        = Expect parenthesis at the end
     func_ret_type           (string)      = Functions return type
-
     Returns
     =======
     string, string, int: The expression, datatype of the expression and the current index in source
@@ -690,24 +685,20 @@ def check_ptr(tokens, i):
 def for_statement(tokens, i, table, func_ret_type):
     """
     Parse for for_loop
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     OpCode, int: The opcode for the for loop code and the index after parsing for loop
-
     Grammar
     =======
     for_loop    -> for id in number to number by operator number
     number      -> [0-9]+
     id          -> [a-zA-Z_]?[a-zA-Z0-9_]*
     operator    -> + | - | * | /
-
     """
 
     # Check if identifier follows for keyword
@@ -771,18 +762,15 @@ def for_statement(tokens, i, table, func_ret_type):
 def while_statement(tokens, i, table, in_do, func_ret_type):
     """
     Parse while statement
-
     Params
     ======
     tokens      (list)        = List of tokens
     i           (int)         = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
     in_do       (bool)        = While is part of do-while or is a separate while
-
     Returns
     =======
     OpCode, int: The opcode for the assign code and the index after parsing while statement
-
     Grammar
     =======
     while_statement -> while(condition) { body }
@@ -802,13 +790,21 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows "(expression)" in while statement
+    # check if expression follows ( in while statement
     op_value, _, i, func_ret_type = expression(
         tokens,
         i,
         table,
         "Expected expression inside while statement",
         func_ret_type=func_ret_type,
+    )
+
+    # check if ) follows expression in while statement
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after expression in while statement",
+        tokens[i - 1].line_num,
     )
 
     # If while is not part of do-while
@@ -853,17 +849,14 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
 def if_statement(tokens, i, table, func_ret_type):
     """
     Parse if statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     OpCode, int: The opcode for the assign code and the index after parsing if statement
-
     Grammar
     =======
     if_statement -> if(condition) { body }
@@ -883,7 +876,7 @@ def if_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows "(expression)" partner in if statement
+    # check if expression follows ( in if statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
         i,
@@ -892,6 +885,13 @@ def if_statement(tokens, i, table, func_ret_type):
         func_ret_type=func_ret_type,
     )
     op_value_list = op_value.replace(" ", "").split(",")
+    # check if ) follows expression in if statement
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after expression in if statement",
+        tokens[i - 1].line_num,
+    )
 
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
@@ -910,7 +910,7 @@ def if_statement(tokens, i, table, func_ret_type):
 
     # Loop until } is reached
     i += 1
-    ret_idx = i
+    ret_idx = i 
     found_right_brace = False
     while i < len(tokens) and tokens[i].type != "right_brace":
         if found_right_brace:
@@ -936,6 +936,13 @@ def switch_statement(tokens, i, table, func_ret_type):
         table,
         "Expected expression inside switch statement",
         func_ret_type=func_ret_type,
+    )
+
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after expression in switch",
+        tokens[i - 1].line_num,
     )
 
     check_if(
@@ -972,18 +979,15 @@ def case_statement(tokens, i, table, func_ret_type):
 def print_statement(tokens, i, table, func_ret_type):
     """
     Parse print statement
-
     Params
     ======
     tokens        (list)        = List of tokens
     i             (int)         = Current index in token
     table         (SymbolTable) = Symbol table constructed holding information about identifiers and constants
     func_ret_type (string)      = Function return type
-
     Returns
     =======
     OpCode, int: The opcode for the print code and the index after parsing print statement
-
     Grammar
     =======
     print_statement -> print(expr)
@@ -1003,7 +1007,7 @@ def print_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # Check if expression follows "(expression)" patner in print statement
+    # Check if expression follows ( in print statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
         i,
@@ -1023,6 +1027,14 @@ def print_statement(tokens, i, table, func_ret_type):
     }
     op_value = prec_to_type[op_type] + op_value[1:-1]
 
+    # Check if print statement has closing )
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after expression in print statement",
+        tokens[i - 1].line_num,
+    )
+
     # Return the opcode and i+1 (the token after print statement)
     return OpCode("print", op_value), i + 1, func_ret_type
 
@@ -1030,18 +1042,15 @@ def print_statement(tokens, i, table, func_ret_type):
 def var_statement(tokens, i, table, func_ret_type):
     """
     Parse variable declaration [/initialization] statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
     func_ret_type (string) = Function return type
-
     Returns
     =======
     OpCode, int: The opcode for the var_assign/var_no_assign code and the index after parsing var statement
-
     Grammar
     =======
     var_statement   -> var id [= expr]?
@@ -1157,17 +1166,14 @@ def var_statement(tokens, i, table, func_ret_type):
 def assign_statement(tokens, i, table, func_ret_type):
     """
     Parse assignment statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     OpCode, int: The opcode for the assign code and the index after parsing assign statement
-
     Grammar
     =======
     var_statement   -> var id [= expr]?
@@ -1274,17 +1280,14 @@ def assign_statement(tokens, i, table, func_ret_type):
 def unary_statement(tokens, i, table, func_ret_type):
     """
     Parse unary statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     OpCode, int: The opcode for the unary code and the index after parsing unary statement
-
     Grammar
     =======
     unary_statement -> id operator
@@ -1333,23 +1336,19 @@ def unary_statement(tokens, i, table, func_ret_type):
 def exit_statement(tokens, i, table, func_ret_type):
     """
     Parse exit statement
-
     Params
     ======
     tokens      (list) = List of tokens
     i           (int)  = Current index in token
     table       (SymbolTable) = Symbol table constructed holding information about identifiers and constants
-
     Returns
     =======
     OpCode, int: The opcode for the assign code and the index after parsing exit statement
-
     Grammar
     =======
     exit_statement -> exit(expr)
     expr            -> number
     number          -> [0-9]+
-
     """
     # Check if ( follows exit statement
     check_if(
@@ -1367,7 +1366,7 @@ def exit_statement(tokens, i, table, func_ret_type):
         tokens[i].line_num,
     )
 
-    # check if expression follows "(expression)" partner in exit statement
+    # check if expression follows ( in exit statement
     op_value, _, i, func_ret_type = expression(
         tokens,
         i,
@@ -1376,6 +1375,13 @@ def exit_statement(tokens, i, table, func_ret_type):
         func_ret_type=func_ret_type,
     )
     op_value_list = op_value.replace(" ", "").split(",")
+    # check if ) follows expression in exit statement
+    check_if(
+        tokens[i - 1].type,
+        "right_paren",
+        "Expected ) after expression in exit statement",
+        tokens[i - 1].line_num,
+    )
 
     return OpCode("exit", op_value[1:-1]), i, func_ret_type
 
@@ -1383,15 +1389,12 @@ def exit_statement(tokens, i, table, func_ret_type):
 def parse(tokens, table):
     """
     Parse tokens and generate opcodes
-
     Params
     ======
     tokens (list) = List of tokens
-
     Returns
     =======
     list: The list of opcodes
-
     Grammar
     =======
     statement -> print_statement | var_statement | assign_statement | function_definition_statement

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -64,7 +64,7 @@ def function_call_statement(tokens, i, table, func_ret_type):
     # Parse the arguments
     op_value, op_type, i, func_ret_type = expression(
         tokens,
-        i + 2,
+        i + 1,
         table,
         "",
         True,
@@ -72,6 +72,8 @@ def function_call_statement(tokens, i, table, func_ret_type):
         expect_paren=True,
         func_ret_type=func_ret_type,
     )
+    # op_value start in 1 because it should start with "params)" not "(params)"
+    op_value = op_value[1:]
     op_value_list = op_value.replace(" ", "").split(",")
     op_value_list = (
         op_value_list if len(op_value_list) > 0 and len(op_value_list[0]) > 0 else []
@@ -446,7 +448,6 @@ def expression(
     string, string, int: The expression, datatype of the expression and the current index in source
                          code after parsing
     """
-
     # Initial values
     op_value = ""
     op_type = -1
@@ -457,6 +458,9 @@ def expression(
     #Mapping simc constant name to c constant name
     math_constants = {"PI":"M_PI", "E":"M_E" , "inf":"INFINITY", "NaN":"NAN"}
     
+    # Count paren
+    count_paren = 0
+
     # Loop until expression is not parsed completely
     while i < len(tokens) and tokens[i].type in [
         "number",
@@ -547,7 +551,6 @@ def expression(
 
                     # Replace all {} in string
                     value = value.replace("{", "").replace("}", "")
-
                 op_value += value
                 op_type = 0 if typedata == "constant" else 1
             elif type == "char":
@@ -611,12 +614,12 @@ def expression(
                 "power": ""
             }
 
-            if (
-                expect_paren
-                and tokens[i].type == "right_paren"
-                and tokens[i + 1].type in ["newline", "left_brace"]
-            ):
-                break
+            # if (
+            #     expect_paren
+            #     and tokens[i].type == "right_paren"
+            #     and tokens[i + 1].type in ["newline", "left_brace"]
+            # ):
+            #     break
 
             if tokens[i].type == "power":
                 # Fetch information from symbol table for first operand
@@ -630,10 +633,23 @@ def expression(
                 op_value += f"pow({value_first}, {value_second})"
 
                 i += 1
+            elif tokens[i].type == "left_paren":
+                # if(tokens[i-1].type != "id"):
+                count_paren += 1;
+                op_value += word_to_op[tokens[i].type]
+            elif tokens[i].type == "right_paren":
+                count_paren -= 1;
+
+                if count_paren < 0:
+                    error("Found unexpected ‘)’ in expression", tokens[i].line_num)
+                op_value += word_to_op[tokens[i].type]
             else:
                 op_value += word_to_op[tokens[i].type]
 
         i += 1
+
+    if count_paren > 0:
+        error("Expected ‘)’ before end of expression", tokens[i].line_num)
 
     # If expression is empty then throw an error
     if op_value == "" and not accept_empty_expression:
@@ -662,7 +678,6 @@ def expression(
         dtype_to_prec = {"i": 3, "f": 4, "d": 5, "s": 1}
         op_value = str(p_msg) + "---" + str(dtype)
         op_type = dtype_to_prec[dtype]
-
     # Return the expression, type of expression, and current index in source codes
     return op_value, op_type, i, func_ret_type
 
@@ -802,7 +817,7 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
     # check if expression follows ( in while statement
     op_value, _, i, func_ret_type = expression(
         tokens,
-        i + 1,
+        i,
         table,
         "Expected expression inside while statement",
         func_ret_type=func_ret_type,
@@ -827,14 +842,14 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
 
         # Check if { follows ) in while statement
         check_if(
-            tokens[i + 1].type,
+            tokens[i].type,
             "left_brace",
             "Expected { before while loop body",
-            tokens[i + 1].line_num,
+            tokens[i].line_num,
         )
 
         # Loop until } is reached
-        i += 2
+        i += 1
         ret_idx = i
         found_right_brace = False
         while i < len(tokens) and tokens[i].type != "right_brace":
@@ -850,9 +865,9 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
         if not found_right_brace:
             error("Expected } after while loop body", tokens[i].line_num)
 
-        return OpCode("while", op_value[:-1]), ret_idx - 1, func_ret_type
+        return OpCode("while", op_value[1:-1]), ret_idx - 1, func_ret_type
     else:
-        return OpCode("while_do", op_value[:-1]), i + 1, func_ret_type
+        return OpCode("while_do", op_value[1:-1]), i + 1, func_ret_type
 
 
 def if_statement(tokens, i, table, func_ret_type):
@@ -891,7 +906,7 @@ def if_statement(tokens, i, table, func_ret_type):
     # check if expression follows ( in if statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
-        i + 1,
+        i,
         table,
         "Expected expression inside if statement",
         func_ret_type=func_ret_type,
@@ -914,11 +929,20 @@ def if_statement(tokens, i, table, func_ret_type):
 
     # Check if { follows ) in if statement
     check_if(
-        tokens[i + 1].type,
+        tokens[i].type,
         "left_brace",
         "Expected { before if body",
-        tokens[i + 1].line_num,
+        tokens[i].line_num,
     )
+
+    # Loop until } is reached
+    i += 1
+    ret_idx = i 
+    found_right_brace = False
+    while i < len(tokens) and tokens[i].type != "right_brace":
+        if found_right_brace:
+            found_right_brace = True
+        i += 1
 
     # Loop until } is reached
     i += 2
@@ -933,11 +957,7 @@ def if_statement(tokens, i, table, func_ret_type):
     if i != len(tokens) and tokens[i].type == "right_brace":
         found_right_brace = True
 
-    # If right brace is not found then produce error
-    if not found_right_brace:
-        error("Expected } after if body", tokens[i].line_num)
-
-    return OpCode("if", op_value[:-1]), ret_idx - 1, func_ret_type
+    return OpCode("if", op_value[1:-1]), ret_idx - 1, func_ret_type
 
 
 def switch_statement(tokens, i, table, func_ret_type):
@@ -948,7 +968,7 @@ def switch_statement(tokens, i, table, func_ret_type):
 
     op_value, _, i, func_ret_type = expression(
         tokens,
-        i + 1,
+        i,
         table,
         "Expected expression inside switch statement",
         func_ret_type=func_ret_type,
@@ -962,13 +982,13 @@ def switch_statement(tokens, i, table, func_ret_type):
     )
 
     check_if(
-        tokens[i + 1].type,
+        tokens[i].type,
         "left_brace",
         "Expected { after switch statement",
         tokens[i].line_num,
     )
 
-    return OpCode("switch", op_value[:-1], ""), i + 1, func_ret_type
+    return OpCode("switch", op_value[1:-1], ""), i, func_ret_type
 
 
 def case_statement(tokens, i, table, func_ret_type):
@@ -1029,7 +1049,7 @@ def print_statement(tokens, i, table, func_ret_type):
     # Check if expression follows ( in print statement
     op_value, op_type, i, func_ret_type = expression(
         tokens,
-        i + 1,
+        i,
         table,
         "Expected expression inside print statement",
         func_ret_type=func_ret_type,
@@ -1044,7 +1064,7 @@ def print_statement(tokens, i, table, func_ret_type):
         4: '"%f", ',
         5: '"%lf", ',
     }
-    op_value = prec_to_type[op_type] + op_value[:-1]
+    op_value = prec_to_type[op_type] + op_value[1:-1]
 
     # Check if print statement has closing )
     check_if(
@@ -1401,7 +1421,7 @@ def exit_statement(tokens, i, table, func_ret_type):
     # check if expression follows ( in exit statement
     op_value, _, i, func_ret_type = expression(
         tokens,
-        i + 1,
+        i,
         table,
         "Expected expression inside exit statement",
         func_ret_type=func_ret_type,
@@ -1415,7 +1435,7 @@ def exit_statement(tokens, i, table, func_ret_type):
         tokens[i - 1].line_num,
     )
 
-    return OpCode("exit", op_value[:-1]), i, func_ret_type
+    return OpCode("exit", op_value[1:-1]), i, func_ret_type
 
 
 def parse(tokens, table):
@@ -1576,7 +1596,6 @@ def parse(tokens, table):
                 tokens, i + 1, table, func_ret_type
             )
             op_codes.append(if_opcode)
-
             # Increment if count on encountering if
             if_count += 1
         # If token is of type exit then generate exit opcode
@@ -1617,10 +1636,10 @@ def parse(tokens, table):
         # If token is of type return then generate return opcode
         elif tokens[i].type == "return":
             beg_idx = i + 1
-            if tokens[i + 1].type not in ["id", "number", "string"]:
+            if tokens[i + 1].type not in ["id", "number", "string", "left_paren"]:
                 op_value = ""
                 op_type = 6
-                i += 2
+                i += 1
             else:
                 op_value, op_type, i, func_ret_type = expression(
                     tokens,


### PR DESCRIPTION
Resolves #26  and #190 

This solution is for bug in parentheses, therefore this resolves #190 and #26 

**What is it changing?**

- All parentheses in **lexical_analyser.py** is stored.
- All expression are fully checked for even number of parentheses
 
The function expression in **simc_parser.py** start reading from left parentheses and will return always  enclosed parentheses, if it is right: "(a+b)", "(c+d)((a+b))", ..

Example to read (a+b) without parentheses: 
`print(op_value[1:-1])  # a+b `

**Advantages**
- This change will bring more flexibility for parentheses cases. 

**NOTE**
On lexical_analyzer.py I increment "line_num += 1" on line 388, is it right? (on my test nothing stranger occured)

**How do I run the tests correct? (this in the simc/test/)**

**One of the test file with all commands affected:**

Input: simc
```
fun sum(a, b) 
{
  return a + b
}

fun sum1(a, b=1) 
{
  return a + b
}

MAIN 
    var i = 45 
    var j = (45 + (0)*(12))
    var k = (45 + (12))
    var l = ((((45))) + (0)*(12))
    var m = (45 + ((0)*(12)))
    var n = (45 + (0)*(12)) + 29
    var o = (45 + (0)*(12)) - (108*17)
    var p = (45 + (0)*(12)) + (2*(17*16))
    if(4 > 2) {
      print("answer")
      print("answer((")
      print(i)
    }

    var n = 1
    for i in 1 to n by +1 {     
        print(i) 
    }

    var i = 0 
    while(i < 10) {
        print(i) 
    } 

    var i = 0 
    do {
        print(i)
    } while(i <= 0)

    if(0){
        print(i)
    }
    else if(1){
        print(i)
    } 
    else{ 
        print(i)
    }
    
    sum(3, 4)
    sum1(3, 4)
    print(3.14159)

    var op = 9
    switch (op) {
        case 8 :  
            print(8)
        case 9 :
            print(9)
        default : return sum(1,2)
    }

    var op = 9
    switch (op) {
        case 8 :  
            print(8)
        case 9 :
            print(9)
        default : return (1+2)
    }
END_MAIN
```

Output: c
```
#include <stdio.h>

int sum(int a, int b) {

	return a + b;
}

int sum1(int a, int b) {

	return a + b;
}

int main() {
	int i = 45;
	int j = (45 + (0) * (12));
	int k = (45 + (12));
	int l = ((((45))) + (0) * (12));
	int m = (45 + ((0) * (12)));
	int n = (45 + (0) * (12)) + 29;
	int o = (45 + (0) * (12)) - (108 * 17);
	int p = (45 + (0) * (12)) + (2 * (17 * 16));
	if(4 > 2) {
	printf("answer");
	printf("%d", i);
	}
	int n = 1;
	for(int i = 1; i < n; i+=1) {
	printf("%d", i);
	}
	int i = 0;
	while(i < 10) {
	printf("%d", i);
	}
	int i = 0;
	do {
	printf("%d", i);
	}
	while(i <= 0);	if(0) {
	printf("%d", i);
	}
	else if(1) {
	printf("%d", i);
	}
	else {
	printf("%d", i);
	}
	sum(3, 4);
	sum1(3, 4);
	printf("%f", 3.14159);
	int op = 9;
	switch(op) {
	case 8:
	printf("%d", 8);
	case 9:
	printf("%d", 9);
	default:

	return sum(1, 2);
	}
	int op = 9;
	switch(op) {
	case 8:
	printf("%d", 8);
	case 9:
	printf("%d", 9);
	default:

	return (1 + 2);
	}

}
```