### PR TITLE
In 342

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -369,6 +369,16 @@ def lexical_analyze(filename, table):
             if parantheses_count > 0:
                 parantheses_count -= 1
                 tokens.append(Token("right_paren", "", line_num))
+
+                # Read spaces between next code
+                while source_code[i+1] is " ":
+                    i += 1
+
+                # End of expression is a right parentheses followed of a new line or left brace
+                if source_code[i + 1] == "\n" or source_code[i + 1] == "left_brace":
+                    print("LEX: " + source_code[i + 1])
+                    tokens.append(Token("call_end", "", line_num))
+
             else:
                error("Parentheses does not match.", line_num);
 
@@ -376,7 +386,7 @@ def lexical_analyze(filename, table):
         # Identifying end of expression
         elif source_code[i] == "\n":
             if parantheses_count == 0:
-                tokens.append(Token("call_end", "", line_num))
+                tokens.append(Token("newline", "", line_num))
             else:
                 error("Parentheses does not match.", line_num);
 
@@ -391,12 +401,6 @@ def lexical_analyze(filename, table):
         # Identifying right brace token
         elif source_code[i] == "}":
             tokens.append(Token("right_brace", "", line_num))
-            i += 1
-
-        # Identifying newline token
-        elif source_code[i] == "\n":
-            tokens.append(Token("newline", "", line_num))
-            line_num += 1
             i += 1
 
         # Identifying assignment token or equivalence token
@@ -540,5 +544,7 @@ def lexical_analyze(filename, table):
         else:
             i += 1
 
+    # tokens.append(Token("call_end", "", line_num))
+    
     # Return the generated tokens
     return tokens

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -371,12 +371,11 @@ def lexical_analyze(filename, table):
                 tokens.append(Token("right_paren", "", line_num))
 
                 # Read spaces between next code
-                while source_code[i+1] is " ":
+                while source_code[i + 1] is " ":
                     i += 1
 
                 # End of expression is a right parentheses followed of a new line or left brace
-                if source_code[i + 1] == "\n" or source_code[i + 1] == "left_brace":
-                    print("LEX: " + source_code[i + 1])
+                if source_code[i + 1] == "\n" or source_code[i + 1] == "{":
                     tokens.append(Token("call_end", "", line_num))
 
             else:

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -374,7 +374,7 @@ def lexical_analyze(filename, table):
                 while source_code[i + 1] is " ":
                     i += 1
 
-                # End of expression is a right parentheses followed of a new line or left brace
+                # Add call_end at end of an expression, which is detected as ")" followed by end line or "{"
                 if source_code[i + 1] == "\n" or source_code[i + 1] == "{":
                     tokens.append(Token("call_end", "", line_num))
 
@@ -542,8 +542,6 @@ def lexical_analyze(filename, table):
         # Otherwise increment the index
         else:
             i += 1
-
-    # tokens.append(Token("call_end", "", line_num))
     
     # Return the generated tokens
     return tokens

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -302,10 +302,10 @@ def function_parameters(
 
         i += 1
 
-        check_if(tokens[i].type,
-                 "call_end",
-                 "End of call expected",
-                 tokens[i].line_num)
+        # check_if(tokens[i].type,
+        #          "call_end",
+        #          "End of call expected",
+        #          tokens[i].line_num)
 
         return [], i
 
@@ -342,10 +342,10 @@ def function_parameters(
                  tokens[i].line_num)
         i += 1
 
-        check_if(tokens[i].type,
-                 "call_end",
-                 "End of call expected",
-                 tokens[i].line_num)
+        # check_if(tokens[i].type,
+        #          "call_end",
+        #          "End of call expected",
+        #          tokens[i].line_num)
 
     else:
         error("Function parameters must be identifiers",
@@ -818,10 +818,10 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
 
         # Check if { follows ) in while statement
         check_if(
-            tokens[i].type,
+            tokens[i + 1].type,
             "left_brace",
             "Expected { before while loop body",
-            tokens[i].line_num,
+            tokens[i + 1].line_num,
         )
 
         # Loop until } is reached
@@ -902,10 +902,10 @@ def if_statement(tokens, i, table, func_ret_type):
 
     # Check if { follows ) in if statement
     check_if(
-        tokens[i].type,
+        tokens[i + 1].type,
         "left_brace",
         "Expected { before if body",
-        tokens[i].line_num,
+        tokens[i + 1].line_num,
     )
 
     # Loop until } is reached
@@ -946,10 +946,10 @@ def switch_statement(tokens, i, table, func_ret_type):
     )
 
     check_if(
-        tokens[i].type,
+        tokens[i + 1].type,
         "left_brace",
         "Expected { after switch statement",
-        tokens[i].line_num,
+        tokens[i + 1].line_num,
     )
 
     return OpCode("switch", op_value[1:-1], ""), i, func_ret_type
@@ -1423,9 +1423,10 @@ def parse(tokens, table):
 
     # Loop through all the tokens
     i = 0
-    while i <= len(tokens) - 1:
-        # If token is raw c type
 
+    while i <= len(tokens) - 1:
+
+        # If token is raw c type
         if tokens[i].type == "RAW_C":
             op_codes.append(OpCode("raw",tokens[i].val))
             i += 1


### PR DESCRIPTION
Resolves #342 

This will allow the declaration of a function with braces "inline", like the following code:

simc:
```
fun test() {
}
```
Until now, it was throwing an error. 

**What is it changing?**

Add call_end at end of an expression, which is detected as ")" followed by end line or "{"
 ```
if source_code[i + 1] == "\n" or source_code[i + 1] == "{":
            tokens.append(Token("call_end", "", line_num))
```

**Teste com comandos afetados**
simc:
```
fun test() {
}

fun test() 
{
    print("I have to work\n")
}

MAIN
    var i = 0 
    while(i < 3) {
        print("Oi")
        ++i
    }
    while(i < 6) 
    {
        print("Em português!")
        ++i
    }
    if(i > 8) 
    {
        print("ola")
    } else if(i < 7) 
    {
        print("De novo?")
    }
    if(i == 8) {
        print("ola")
    }

    switch (i) {
        case 8 :  
            print(8)
        case 9 :
            print(9)
        default : return (1+2)
    }
 
END_MAIN
```
Output:
```
#include <stdio.h>

void test(void) {
}

void test(void) {
	printf("I have to work\n");
}

int main() {
	int i = 0;
	while(i < 3) {
	printf("Oi");
	++i;
	}
	while(i < 6) {
	printf("Em português!");
	++i;
	}
	if(i > 8) {
	printf("ola");
	}
	else if(i < 7) {
	printf("De novo?");
	}
	if(i == 8) {
	printf("ola");
	}
	switch(i) {
	case 8:
	printf("%d", 8);
	case 9:
	printf("%d", 9);
	default:

	return (1 + 2);
	}

}
```
