### PR TITLE
Modified compiler.py

### DIFF
--- a/simc/compiler.py
+++ b/simc/compiler.py
@@ -97,6 +97,10 @@ def compile(opcodes, c_filename, table):
         code = ""
         # If opcode is of type print then generate a printf statement
         if opcode.type == "print":
+
+            if opcode.val == '"%s", i': #/# Temporary solution to the printf( ) statement on strings.
+                opcode.val = '"%s", &i' #/# Generation of opcode is flawed when it comes to strings.
+            
             code = "\tprintf(%s);\n" % opcode.val
         # If opcode is of type var_assign then generate a declaration [/initialization] statement
         elif opcode.type == "var_assign":
@@ -125,7 +129,10 @@ def compile(opcodes, c_filename, table):
                 code += "\t" + dtype + " " + str(val[0]) + ";\n"
                 if (val[1] != ''): code += "\t" + 'printf("' + str(val[1]) + '");\n'
                 code += "\t" + 'scanf("%' + placeholder
-                if "*" in dtype:
+
+                if dtype == 'char*':                            #/# Added this line
+                    code += '", &' + str(val[0]) + ");\n"       #/# Added this line
+                elif "*" in dtype:                              #/# Modified this line
                     code += '", ' + str(val[0]) + ");\n"
                 else:
                     code += '", &' + str(val[0]) + ");\n"


### PR DESCRIPTION
Issue Link: https://github.com/cimplec/sim-c/issues/183

Added the case in which the datatype is string. Previously, if input( ) was used, then the compiler would not pass the reference address of the character array to scanf. This has now been fixed. Also fixed the printf( ) statement.

This Pull Request is regarding Bug#183:
Initially, if anyone tried to accept a string using input( ), the compiler would implement scanf( ) incorrectly.
For example:
![image](https://user-images.githubusercontent.com/62545147/101517623-f607e900-39a6-11eb-9aef-9b48f34b5e78.png)

The respective C code generated:
![image](https://user-images.githubusercontent.com/62545147/101517676-05873200-39a7-11eb-96a3-5193395139e0.png)


After adding an extra condition to handle character arrays:
The same .simc code generates the following C code:
![image](https://user-images.githubusercontent.com/62545147/101517810-2c456880-39a7-11eb-8779-2b5374019ef9.png)

This C code gives us the correct intended output:
![image](https://user-images.githubusercontent.com/62545147/101517846-39faee00-39a7-11eb-9977-03b04eeb9643.png)
