### PR TITLE
[BUG] check_if always overflow

### DIFF
--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -812,7 +812,7 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
         # If \n follows ) then skip all the \n characters
         if tokens[i + 1].type == "newline":
             i += 1
-            while i > len(tokens) and tokens[i].type == "newline":
+            while tokens[i].type == "newline":
                 i += 1
             i -= 1
 
@@ -896,7 +896,7 @@ def if_statement(tokens, i, table, func_ret_type):
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
         i += 1
-        while i > len(tokens) and tokens[i].type == "newline":
+        while tokens[i].type == "newline":
             i += 1
         i -= 1
 

--- a/simc/simc_parser.py
+++ b/simc/simc_parser.py
@@ -812,7 +812,7 @@ def while_statement(tokens, i, table, in_do, func_ret_type):
         # If \n follows ) then skip all the \n characters
         if tokens[i + 1].type == "newline":
             i += 1
-            while tokens[i].type == "newline":
+            while i > len(tokens) and tokens[i].type == "newline":
                 i += 1
             i -= 1
 
@@ -896,7 +896,7 @@ def if_statement(tokens, i, table, func_ret_type):
     # If \n follows ) then skip all the \n characters
     if tokens[i + 1].type == "newline":
         i += 1
-        while tokens[i].type == "newline":
+        while i > len(tokens) and tokens[i].type == "newline":
             i += 1
         i -= 1
 


### PR DESCRIPTION
Trying to fix #361 bug, and it is fixed, showing error " Expected { before if body ":
```
MAIN
    if()
```

But, when I ran the program:
```
MAIN
    if()
    {
    }
```
Then, again it showing the error which is showing in above case.

So, someone please help me to resolve this.