### PR TITLE
Fixed issue 402. Now simc programs with unbalanced brackets will raise an error.

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -418,9 +418,9 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing simple parentheses '()' at line:", line_num )
+                error( "Too many closing parentheses", line_num )
             elif balanced_brackets_stack[ top ] != '(':
-                error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % source_code[i], line_num )
+                error( "Unbalanced parentheses error", line_num )
 
 
             else:
@@ -440,7 +440,7 @@ def lexical_analyze(filename, table):
                     tokens.append(Token("call_end", "", line_num))
 
             else:
-               error("Parentheses does not match.", line_num);
+               error("Parentheses does not match", line_num)
 
             got_num_or_var = False
             i += 1
@@ -450,7 +450,7 @@ def lexical_analyze(filename, table):
             if parantheses_count == 0:
                 tokens.append(Token("newline", "", line_num))
             else:
-                error("Parentheses does not match.", line_num);
+                error("Parentheses does not match.", line_num)
 
             i += 1
             line_num += 1
@@ -472,9 +472,9 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing braces '{ }' at line:", line_num )
+                error( "Too many closing braces", line_num )
             elif balanced_brackets_stack[ top ] != '{':
-                error( "Unbalanced Braces Error. Bracket: %s mismatch" % source_code[i], line_num )
+                error( "Unbalanced braces error", line_num )
 
             else:
                 top -= 1
@@ -500,9 +500,9 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing square brackets '[]' at line:", line_num )
+                error( "Too many closing brackets", line_num )
             elif balanced_brackets_stack[ top ] != '[':
-                error( "Unbalanced Brackets Error. Bracket: %s mismatch" % source_code[i], line_num )
+                error( "Unbalanced brackets error", line_num )
                 
             else:
                 top -= 1
@@ -692,12 +692,7 @@ def lexical_analyze(filename, table):
     
     # By the end, if stack is not empty, there are extra opening brackets
     if top != -1:
-        if balanced_brackets_stack[ top ] == '(':
-            error( "Unbalanced Parentheses Error! Too many opening simple parentheses '()'.", line_num )
-        elif balanced_brackets_stack[ top ] == '[':
-            error( "Unbalanced Brackets Error! Too many opening square brackets '[]'.", line_num )
-        elif balanced_brackets_stack[ top ] == '{':
-            error( "Unbalanced Braces Error! Too many opening brackets '{ }'.", line_num )
+        error( "Unbalanced parenthesis error", line_num )
         
     # Return the generated tokens
     return tokens, module_source_paths

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -418,9 +418,10 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing simple brackets ')' at line:", line_num )
+                error( "Too many closing simple parentheses '()' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '(':
-                error( "Unbalanced Brackets Detected!", line_num )
+                error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+                
             else:
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
@@ -470,9 +471,10 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing flower brackets '}' at line:", line_num )
+                error( "Too many closing braces '{ }' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '{':
-                error( "Unbalanced Brackets Detected!", line_num )
+                error( "Unbalanced Braces Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+
             else:
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
@@ -497,9 +499,10 @@ def lexical_analyze(filename, table):
                 # If at any time there is underflow, there are too many closing brackets.
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing square brackets ']' at line:", line_num )
+                error( "Too many closing square brackets '[]' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '[':
-                error( "Unbalanced Brackets Detected!", line_num )
+                error( "Unbalanced Brackets Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+                
             else:
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
@@ -686,9 +689,14 @@ def lexical_analyze(filename, table):
         else:
             i += 1
     
-    # By the end, if any stack is not empty, there are extra opening brackets
+    # By the end, if stack is not empty, there are extra opening brackets
     if top != -1:
-            error( "Brackets Unbalanced Error! There are too many opening braces", line_num )
+        if balanced_brackets_stack[ top ] == '(':
+            error( "Unbalanced Parentheses Error! Too many opening simple parentheses '()'.", line_num )
+        elif balanced_brackets_stack[ top ] == '[':
+            error( "Unbalanced Brackets Error! Too many opening square brackets '[]'.", line_num )
+        elif balanced_brackets_stack[ top ] == '{':
+            error( "Unbalanced Braces Error! Too many opening brackets '{ }'.", line_num )
         
     # Return the generated tokens
     return tokens, module_source_paths

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -420,7 +420,6 @@ def lexical_analyze(filename, table):
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
                 error( "Too many closing simple parentheses '()' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '(':
-                #error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
                 error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % source_code[i], line_num )
 
 

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -357,8 +357,6 @@ def lexical_analyze(filename, table):
     tops             = [ top_0, top_1, top_2 ]
     brackets         = [ '(', '[', '{' ]
     closing_brackets = [ ')', ']', '}' ]
-
-    length = len( string )
     
     while source_code[i] != "\0":
 
@@ -371,12 +369,12 @@ def lexical_analyze(filename, table):
 
         # To check if brackets are balanced:
         for j in range( 0, 3 ):
-            if string[ i ] == brackets[ j ]:
+            if source_code[ i ] == brackets[ j ]:
                 # If an opening brace is seen, push element to stack
                 tops[ j ] += 1
                 stacks[ j ].append( '*' )
             
-            if string[ i ] == closing_brackets[ j ]:
+            if source_code[ i ] == closing_brackets[ j ]:
                 if tops[ j ] == -1:
                     # If at any time there is an underflow, the string is not balanced, 
                     # because there is an extra closing bracket
@@ -675,8 +673,6 @@ def lexical_analyze(filename, table):
     for i in range( 0, 3 ):
         if tops[i] != -1:
             error ( " Bracket %s is not balanced! Too many openening braces." % brackets[ i ], line_num )
-            return 0
-    return 1
 
     # Return the generated tokens
     return tokens, module_source_paths

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -341,22 +341,8 @@ def lexical_analyze(filename, table):
     got_num_or_var = False
 
     # To check if the brackets are balanced:
-    # For simple parenthesis
-    stack_0 = []
-    top_0 = -1
-
-    # For square brackets
-    stack_1 = []
-    top_1 = -1
-
-    # For flower brackets
-    stack_2 = []
-    top_2 = -1
-
-    stacks           = [ stack_0, stack_1, stack_2 ] 
-    tops             = [ top_0, top_1, top_2 ]
-    brackets         = [ '(', '[', '{' ]
-    closing_brackets = [ ')', ']', '}' ]
+    top = -1
+    balanced_brackets_stack = [ ]
     
     while source_code[i] != "\0":
 
@@ -368,22 +354,55 @@ def lexical_analyze(filename, table):
             got_num_or_var = False
 
         # To check if brackets are balanced:
-        for j in range( 0, 3 ):
-            if source_code[ i ] == brackets[ j ]:
-                # If an opening brace is seen, push element to stack
-                tops[ j ] += 1
-                stacks[ j ].append( '*' )
-            
-            if source_code[ i ] == closing_brackets[ j ]:
-                if tops[ j ] == -1:
-                    # If at any time there is an underflow, the string is not balanced, 
-                    # because there is an extra closing bracket
-                    tops[ j ] -= 1
-                    error ( " Bracket %s is not balanced! Too many closing braces" % brackets[ j ], line_num )
+        # Checking if ( ) have been balanced
+        if source_code[ i ] == '(':
+            top += 1
+            balanced_brackets_stack.append( '(' )
+        elif source_code[ i ] == ')':
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing simple brackets ')' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '(':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
 
-                else:
-                    tops[ j ] -= 1
-            
+        # Checking if [ ] have been balanced
+        elif source_code[ i ] == '[':
+            top += 1
+            balanced_brackets_stack.append( '[' )
+        elif source_code[ i ] == ']':
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing square brackets ']' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '[':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+
+        # Checking if { } have been balanced
+        elif source_code[ i ] == '{':
+            top += 1
+            balanced_brackets_stack.append( '{' )
+        elif source_code[ i ] == '}':
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing flower brackets '}' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '{':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+        
+
         # If a digit appears, call numeric_val function and add the numeric token to list,
         # if it was correct
         if is_digit(source_code[i]):
@@ -670,9 +689,8 @@ def lexical_analyze(filename, table):
             i += 1
     
     # By the end, if any stack is not empty, there are extra opening brackets
-    for i in range( 0, 3 ):
-        if tops[i] != -1:
-            error ( " Bracket %s is not balanced! Too many openening braces." % brackets[ i ], line_num )
-
+    if top != -1:
+            error( "Brackets Unbalanced Error! There are too many opening braces", line_num )
+        
     # Return the generated tokens
     return tokens, module_source_paths

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -351,57 +351,7 @@ def lexical_analyze(filename, table):
             raw_tokens,i,line_num = get_raw_tokens(source_code,i,line_num)
             tokens.extend(raw_tokens)
             raw_c = False
-            got_num_or_var = False
-
-        # To check if brackets are balanced:
-        # Checking if ( ) have been balanced
-        if source_code[ i ] == '(':
-            top += 1
-            balanced_brackets_stack.append( '(' )
-        elif source_code[ i ] == ')':
-            if top == -1:
-                # If at any time there is underflow, there are too many closing brackets.
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing simple brackets ')' at line:", line_num )
-            elif balanced_brackets_stack[ top ] != '(':
-                error( "Unbalanced Brackets Detected!", line_num )
-            else:
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-
-        # Checking if [ ] have been balanced
-        elif source_code[ i ] == '[':
-            top += 1
-            balanced_brackets_stack.append( '[' )
-        elif source_code[ i ] == ']':
-            if top == -1:
-                # If at any time there is underflow, there are too many closing brackets.
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing square brackets ']' at line:", line_num )
-            elif balanced_brackets_stack[ top ] != '[':
-                error( "Unbalanced Brackets Detected!", line_num )
-            else:
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-
-        # Checking if { } have been balanced
-        elif source_code[ i ] == '{':
-            top += 1
-            balanced_brackets_stack.append( '{' )
-        elif source_code[ i ] == '}':
-            if top == -1:
-                # If at any time there is underflow, there are too many closing brackets.
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-                error( "Too many closing flower brackets '}' at line:", line_num )
-            elif balanced_brackets_stack[ top ] != '{':
-                error( "Unbalanced Brackets Detected!", line_num )
-            else:
-                top -= 1
-                balanced_brackets_stack = balanced_brackets_stack[ :-1]
-        
+            got_num_or_var = False        
 
         # If a digit appears, call numeric_val function and add the numeric token to list,
         # if it was correct
@@ -452,6 +402,10 @@ def lexical_analyze(filename, table):
 
         # Identifying left paren token
         elif source_code[i] == "(":
+            # To check if brackets are balanced:
+            top += 1
+            balanced_brackets_stack.append( '(' )
+
             parantheses_count += 1
             tokens.append(Token("left_paren", "", line_num))
             i += 1
@@ -459,6 +413,18 @@ def lexical_analyze(filename, table):
 
         # Identifying right paren token
         elif source_code[i] == ")":
+            # To check if brackets are balanced:
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing simple brackets ')' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '(':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+
             if parantheses_count > 0:
                 parantheses_count -= 1
                 tokens.append(Token("right_paren", "", line_num))
@@ -489,23 +455,55 @@ def lexical_analyze(filename, table):
 
         # Identifying left brace token
         elif source_code[i] == "{":
+            # To check if brackets are balanced:
+            top += 1
+            balanced_brackets_stack.append( '{' )
+
             tokens.append(Token("left_brace", "", line_num))
             i += 1
             got_num_or_var = False
 
         # Identifying right brace token
         elif source_code[i] == "}":
+            # To check if brackets are balanced:
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing flower brackets '}' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '{':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+
             tokens.append(Token("right_brace", "", line_num))
             i += 1
             got_num_or_var = False
 
         # Identifying left bracket token
         elif source_code[i] == "[":
+            # To check if brackets are balanced:
+            top += 1
+            balanced_brackets_stack.append( '[' )
+
             tokens.append(Token("left_bracket", "", line_num))
             i += 1
 
         # Identifying right bracket token
         elif source_code[i] == "]":
+            # To check if brackets are balanced:
+            if top == -1:
+                # If at any time there is underflow, there are too many closing brackets.
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+                error( "Too many closing square brackets ']' at line:", line_num )
+            elif balanced_brackets_stack[ top ] != '[':
+                error( "Unbalanced Brackets Detected!", line_num )
+            else:
+                top -= 1
+                balanced_brackets_stack = balanced_brackets_stack[ :-1]
+
             tokens.append(Token("right_bracket", "", line_num))
             i += 1
             

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -420,8 +420,10 @@ def lexical_analyze(filename, table):
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
                 error( "Too many closing simple parentheses '()' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '(':
-                error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
-                
+                #error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+                error( "Unbalanced Parentheses Error. Bracket: %s mismatch" % source_code[i], line_num )
+
+
             else:
                 top -= 1
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
@@ -473,7 +475,7 @@ def lexical_analyze(filename, table):
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
                 error( "Too many closing braces '{ }' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '{':
-                error( "Unbalanced Braces Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+                error( "Unbalanced Braces Error. Bracket: %s mismatch" % source_code[i], line_num )
 
             else:
                 top -= 1
@@ -501,7 +503,7 @@ def lexical_analyze(filename, table):
                 balanced_brackets_stack = balanced_brackets_stack[ :-1]
                 error( "Too many closing square brackets '[]' at line:", line_num )
             elif balanced_brackets_stack[ top ] != '[':
-                error( "Unbalanced Brackets Error. Bracket: %s mismatch" % balanced_brackets_stack[top], line_num )
+                error( "Unbalanced Brackets Error. Bracket: %s mismatch" % source_code[i], line_num )
                 
             else:
                 top -= 1

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -289,66 +289,6 @@ def get_raw_tokens(source_code,i,line_num):
         line_num += 1
 
 
-def check_if_balanced_parenthesis( string ):
-    """
-    Function takes a string as the argument. Checks if '(', '[', '{' type of brackets are balanced.
-    If the bracket is balanced, function returns 1. Else it will return 0.
-    For example, 
-    string = "{hello {world} } {my( name)[ is Coder}{}"
-    Output: 0, since square brackets are not balanced.
-    string = "{hello {world} } {my( name)[ is TopCoder]}{}
-    Output: 1
-    """
-    line_num = 1
-
-    # For simple parenthesis
-    stack_0 = []
-    top_0 = -1
-
-    # For square brackets
-    stack_1 = []
-    top_1 = -1
-
-    # For flower brackets
-    stack_2 = []
-    top_2 = -1
-
-    stacks           = [ stack_0, stack_1, stack_2 ] 
-    tops             = [ top_0, top_1, top_2 ]
-    brackets         = [ '(', '[', '{' ]
-    closing_brackets = [ ')', ']', '}' ]
-
-
-    length = len( string )
-    for i in range( 0, length ):
-        for j in range( 0, 3 ):
-            
-            if string[ i ] == brackets[ j ]:
-                # If an opening brace is seen, push element to stack
-                tops[ j ] += 1
-                stacks[ j ].append( '*' )
-            
-            if string[ i ] == closing_brackets[ j ]:
-                if tops[ j ] == -1:
-                    # If at any time there is an underflow, the string is not balanced, 
-                    # because there is an extra closing bracket
-                    tops[ j ] -= 1
-                    error ( " Bracket %s is not balanced! Too many closing braces" % brackets[ j ], line_num )
-                    return 0
-
-                else:
-                    tops[ j ] -= 1
-        if string[ i ] == '\n':
-            line_num += 1
-        
-    # By the end, if any stack is not empty, there are extra opening brackets
-    for i in range( 0, 3 ):
-        if tops[i] != -1:
-            error ( " Bracket %s is not balanced! Too many openening braces." % brackets[ i ], line_num )
-            return 0
-    return 1
-
-
 def lexical_analyze(filename, table):
     """
     Generate tokens from source code
@@ -370,11 +310,6 @@ def lexical_analyze(filename, table):
     # Read the entire source code as a string
     source_code = open(filename, "r").read()
     source_code += "\0"
-
-    # Performing a check to see if all the brackets have been balanced or not:
-    bracket_check_result = check_if_balanced_parenthesis( source_code )
-    if bracket_check_result == 0:
-        error( "Parenthesis Unbalanced Error", 0 )
 
     # List of tokens
     tokens = []
@@ -404,6 +339,26 @@ def lexical_analyze(filename, table):
     # This is to presently differentiate between bitwise and
     # and address of operations.
     got_num_or_var = False
+
+    # To check if the brackets are balanced:
+    # For simple parenthesis
+    stack_0 = []
+    top_0 = -1
+
+    # For square brackets
+    stack_1 = []
+    top_1 = -1
+
+    # For flower brackets
+    stack_2 = []
+    top_2 = -1
+
+    stacks           = [ stack_0, stack_1, stack_2 ] 
+    tops             = [ top_0, top_1, top_2 ]
+    brackets         = [ '(', '[', '{' ]
+    closing_brackets = [ ')', ']', '}' ]
+
+    length = len( string )
     
     while source_code[i] != "\0":
 
@@ -413,6 +368,23 @@ def lexical_analyze(filename, table):
             tokens.extend(raw_tokens)
             raw_c = False
             got_num_or_var = False
+
+        # To check if brackets are balanced:
+        for j in range( 0, 3 ):
+            if string[ i ] == brackets[ j ]:
+                # If an opening brace is seen, push element to stack
+                tops[ j ] += 1
+                stacks[ j ].append( '*' )
+            
+            if string[ i ] == closing_brackets[ j ]:
+                if tops[ j ] == -1:
+                    # If at any time there is an underflow, the string is not balanced, 
+                    # because there is an extra closing bracket
+                    tops[ j ] -= 1
+                    error ( " Bracket %s is not balanced! Too many closing braces" % brackets[ j ], line_num )
+
+                else:
+                    tops[ j ] -= 1
             
         # If a digit appears, call numeric_val function and add the numeric token to list,
         # if it was correct
@@ -698,6 +670,13 @@ def lexical_analyze(filename, table):
         # Otherwise increment the index
         else:
             i += 1
+    
+    # By the end, if any stack is not empty, there are extra opening brackets
+    for i in range( 0, 3 ):
+        if tops[i] != -1:
+            error ( " Bracket %s is not balanced! Too many openening braces." % brackets[ i ], line_num )
+            return 0
+    return 1
 
     # Return the generated tokens
     return tokens, module_source_paths

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -288,6 +288,67 @@ def get_raw_tokens(source_code,i,line_num):
         i += 1
         line_num += 1
 
+
+def check_if_balanced_parenthesis( string ):
+    """
+    Function takes a string as the argument. Checks if '(', '[', '{' type of brackets are balanced.
+    If the bracket is balanced, function returns 1. Else it will return 0.
+    For example, 
+    string = "{hello {world} } {my( name)[ is Coder}{}"
+    Output: 0, since square brackets are not balanced.
+    string = "{hello {world} } {my( name)[ is TopCoder]}{}
+    Output: 1
+    """
+    line_num = 1
+
+    # For simple parenthesis
+    stack_0 = []
+    top_0 = -1
+
+    # For square brackets
+    stack_1 = []
+    top_1 = -1
+
+    # For flower brackets
+    stack_2 = []
+    top_2 = -1
+
+    stacks           = [ stack_0, stack_1, stack_2 ] 
+    tops             = [ top_0, top_1, top_2 ]
+    brackets         = [ '(', '[', '{' ]
+    closing_brackets = [ ')', ']', '}' ]
+
+
+    length = len( string )
+    for i in range( 0, length ):
+        for j in range( 0, 3 ):
+            
+            if string[ i ] == brackets[ j ]:
+                # If an opening brace is seen, push element to stack
+                tops[ j ] += 1
+                stacks[ j ].append( '*' )
+            
+            if string[ i ] == closing_brackets[ j ]:
+                if tops[ j ] == -1:
+                    # If at any time there is an underflow, the string is not balanced, 
+                    # because there is an extra closing bracket
+                    tops[ j ] -= 1
+                    error ( " Bracket %s is not balanced! Too many closing braces" % brackets[ j ], line_num )
+                    return 0
+
+                else:
+                    tops[ j ] -= 1
+        if string[ i ] == '\n':
+            line_num += 1
+        
+    # By the end, if any stack is not empty, there are extra opening brackets
+    for i in range( 0, 3 ):
+        if tops[i] != -1:
+            error ( " Bracket %s is not balanced! Too many openening braces." % brackets[ i ], line_num )
+            return 0
+    return 1
+
+
 def lexical_analyze(filename, table):
     """
     Generate tokens from source code
@@ -309,6 +370,11 @@ def lexical_analyze(filename, table):
     # Read the entire source code as a string
     source_code = open(filename, "r").read()
     source_code += "\0"
+
+    # Performing a check to see if all the brackets have been balanced or not:
+    bracket_check_result = check_if_balanced_parenthesis( source_code )
+    if bracket_check_result == 0:
+        error( "Parenthesis Unbalanced Error", 0 )
 
     # List of tokens
     tokens = []


### PR DESCRIPTION
Fixed #402
now the program gives an error if the brackets are not balanced. Checks for simple parenthesis '(', square brackets '[', and flower brackets '{' as well.
@Math-O5 @frankhart2018 