### PR TITLE
Parse array indexing in expression

### DIFF
--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -73,6 +73,19 @@ def expression(
             type_to_prec = {"char*": 1, "char": 2, "int": 3, "float": 4, "double": 5}
             op_type = type_to_prec[table.get_by_id(table.get_by_symbol(val[0]))[1]]
             i -= 1
+        # Array indexing
+        elif tokens[i].type == "id" and tokens[i + 1].type == "left_bracket":
+            arr_id_idx = i
+            i += 2
+
+            # Check if index is of integer type or not
+            _, type_, _ = table.get_by_id(tokens[i].val)
+            if tokens[i].type == "number" and type_ == "int":
+                pass
+            else:
+                arr_name, _, _ = table.get_by_id(tokens[arr_id_idx].val)
+                error(f"Index of array {arr_name} should be an integer", tokens[i].line_num)
+                
         # If token is identifier or constant
         elif tokens[i].type in ["number", "string", "id", "bool"]:
             # Fetch information from symbol table

--- a/simc/parser/variable_parser.py
+++ b/simc/parser/variable_parser.py
@@ -151,6 +151,9 @@ def var_statement(tokens, i, table, func_ret_type):
             # Modify datatype of the identifier
             table.symbol_table[tokens[id_idx].val][1] = prec_to_type[op_type]
 
+            # Add the size of array to metadata (typedata) in symbol table
+            table.symbol_table[tokens[id_idx].val][2] = size_of_array if size_of_array != "" else -1
+
             # Return the opcode and i (the token after var statement)
             return (
                 OpCode(


### PR DESCRIPTION
Closes #346.

Added array indexing in expression function. Added two checks:-

- Check for integer index only.
- Check for index out of bounds.

**Test Case 1**

simC Code:-

```
MAIN
    var arr[5] = {1, 2, 3, 4, 5}
    var b = arr[2] + 1
END_MAIN
```

C Code:-

```c
#include <stdio.h>

int main() {
    int arr[5] = {1, 2, 3, 4, 5};
    int b = arr[2] + 1;

    return 0;
}
```

**Test Case 2**

simC Code:-

```
MAIN
    var arr[5] = {1, 2, 3, 4, 5}
    var b = arr[8] + 1
END_MAIN
```

Error:-

```bash
[Line 2] Error: Index of array a should be in range [0, 4]  
```

**Test Case 3**

simC Code:-

```
MAIN
    var arr[5] = {1, 2, 3, 4, 5}
    var b = arr[8.14] + 1
END_MAIN
```

Error:-

```bash
[Line 2] Error: Index of array a should be an integer 
```

All unit tests and code tests passing. New tests to be added for this PR. 
