### PR TITLE
Structure instantiation

### DIFF
--- a/simc/compiler.py
+++ b/simc/compiler.py
@@ -344,6 +344,12 @@ def compile(opcodes, c_filename, table):
 
             # append the struct keyword and structure nameto the code
             code += "\n" + "struct" + " " + struct_name + " "
+        # If opcode is of type struct_instantiate then generate structure instantiation statement
+        elif opcode.type == "struct_instantiate":
+            # Extract the identifier name of instance variable
+            struct_name, instance_var_name = opcode.val.split("---")
+
+            code += "\t" + "struct " + struct_name.strip() + " " + instance_var_name.strip() + ";\n"
         # If opcode is of type scope_begin then generate open brace statement
         elif opcode.type == "scope_begin":
             code += "{\n"

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -579,6 +579,22 @@ def parse(tokens, table):
             # Handle variables inside for loop
             elif tokens[i + 1].type in ["to", "by"] or tokens[i - 2].type == "by":
                 i += 1
+
+            # Handle local struct instantiation
+            elif tokens[i+1].type == "id":
+                # Get the details of id at index i - expected to be name of struct
+                struct_name, type_, _ = table.get_by_id(tokens[i].val)
+
+                # Check if the structure is declared or not
+                if(type_ != "struct_var"):
+                    error(f"Structure {struct_name} not declared", tokens[i].line_num)
+
+                # If there is no error then get the name of the instance variable
+                instance_var_name, _, _ = table.get_by_id(tokens[i+1].val)
+
+                op_codes.append(OpCode("struct_instantiate", instance_var_name))
+
+                i += 2    
             else:
                 assign_opcode, i, func_ret_type = assign_statement(
                     tokens, i + 1, table, func_ret_type

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -592,7 +592,8 @@ def parse(tokens, table):
                 # If there is no error then get the name of the instance variable
                 instance_var_name, _, _ = table.get_by_id(tokens[i+1].val)
 
-                op_codes.append(OpCode("struct_instantiate", instance_var_name))
+                # OpCode value will be <struct-name>---<instance-variable-name>
+                op_codes.append(OpCode("struct_instantiate", struct_name + "---" + instance_var_name))
 
                 i += 2    
             else:

--- a/simc/parser/struct_parser.py
+++ b/simc/parser/struct_parser.py
@@ -26,6 +26,9 @@ def struct_declaration_statement(tokens, i, table):
     # Store the id of strcuture name in symbol table
     struct_idx = tokens[i].val
 
+    # Update type to hold struct_var instead of var 
+    table.symbol_table[struct_idx][1] = "struct_var"
+
     # Get struct name
     struct_name, _, _ = table.get_by_id(struct_idx)
 


### PR DESCRIPTION
Closes #358 

Parsed structure instantiation to <b>struct_instantiate</b> opcode. This opcode has the name of structure and instance variable separated by --- as its value. The compiler simply generates - struct <struct-name> <instance-variable-name>. E.g:-  struct student stu.

Also when generating struct_decl opcode, updated symbol table to change the type of the structure from var to struct_var. Eases the check of struct declaration. 

**Test Case 1**

**simC Code**

```
struct student {
    var a = 1
    var b = 3.14
}

MAIN
    student stu
END_MAIN
```

**C Code**

```c
struct student {
    int a = 1;
    float b = 3.14;
} ;

int main() {
    struct student stu;

    return 0;
}
```

All unit and code tests are passing. New tests to be added to accommodate the new opcode, added placeholders for these in <a href="https://github.com/cimplec/test-suite">test-suite</a>. 