### PR TITLE
Explicit typecasting

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -357,6 +357,7 @@ class LexicalAnalyzer:
         # This helps in case of explicit type casting
         if allow_c_keyword:
             self.tokens.append(Token("type_cast", value, self.line_num))
+            return
         else:
             if value in C_keywords:
                 error("A keyword cannot be an identifier - %s" % value, self.line_num)

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -317,6 +317,14 @@ class LexicalAnalyzer:
             value += self.source_code[self.current_source_index]
             self.__update_source_index()
 
+        # Check if value (name of type) is valid or not
+        allowed_dtypes_for_casting = ["int", "float", "double"]
+
+        # Check if next character is (, then it can possibly be explicit typecasting
+        allow_c_keyword = False
+        if self.source_code[self.current_source_index] == "(" and value in allowed_dtypes_for_casting:
+            allow_c_keyword = True
+        
         # For generating bool or math constant type tokens
         types = namedtuple("types", ["data_type", "token_type"])
         const_with_types = {
@@ -345,9 +353,13 @@ class LexicalAnalyzer:
 
         C_keywords = self.c_unique_keywords + self.common_simc_c_keywords
 
-        # Check if identifier is a keyword in class
-        if value in C_keywords:
-            error("A keyword cannot be an identifier - %s" % value, self.line_num)
+        # If this flag is true then we won't throw error when C keyword is used as id
+        # This helps in case of explicit type casting
+        if allow_c_keyword:
+            self.tokens.append(Token("type_cast", value, self.line_num))
+        else:
+            if value in C_keywords:
+                error("A keyword cannot be an identifier - %s" % value, self.line_num)
 
         # Check if identifier is in symbol self.symbol_table
         id_ = self.symbol_table.get_by_symbol(value)

--- a/simc/parser/parser_constants.py
+++ b/simc/parser/parser_constants.py
@@ -43,6 +43,7 @@ OP_TOKENS = [
     "right_shift",
     "left_shift",
     "bool",
+    "type_cast",
 ]
 
 WORD_TO_OP = {


### PR DESCRIPTION
CLoses #30.

**Implementation details**
1) Identified the calls to explicit type casting as type_cast token, this token has the dtype to which the casting is to be done as its value.
2) Parse the type_cast and then update op_type in expression according to the explicit type. 

**Test Case 1**

**simC Code**

```
MAIN
	var i = double(3) + 2
	var b = int(i)
END_MAIN
```

**C Code**

```c
int main() {
	double i = (double)(3) + 2;
	int b = (int)(i);

	return 0;
}
```

All unit and code tests passing. New tests to be added to accomodate this. 