### PR TITLE
Sizeof operator

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -59,6 +59,7 @@ class LexicalAnalyzer:
             "to",
             "true",
             "var",
+            "size",
         ]
 
         self.c_unique_keywords = [

--- a/simc/parser/parser_constants.py
+++ b/simc/parser/parser_constants.py
@@ -44,6 +44,7 @@ OP_TOKENS = [
     "left_shift",
     "bool",
     "type_cast",
+    "size",
 ]
 
 WORD_TO_OP = {

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -128,7 +128,10 @@ def expression(
                 func_ret_type=func_ret_type,
             )
 
-            print(tokens[i])
+            op_value = "sizeof" + op_value + ""
+
+            # sizeof returns int
+            op_type = 3
 
         # If token is identifier or constant
         elif tokens[i].type in ["number", "string", "id", "bool"]:

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -116,6 +116,20 @@ def expression(
             # Convert (<expr>) to (<dtype>)(<expr>)
             op_value = "(" + explicit_dtype + ")" + op_value
 
+        # sizeof operator - size in simC
+        elif tokens[i].type == "size" and tokens[i + 1].type == "left_paren":
+            op_value, op_type, i, func_ret_type = expression(
+                tokens,
+                i + 1,
+                table,
+                "Expected expression inside size statement",
+                expect_paren=True,
+                break_at_last_closed_paren=True,
+                func_ret_type=func_ret_type,
+            )
+
+            print(tokens[i])
+
         # If token is identifier or constant
         elif tokens[i].type in ["number", "string", "id", "bool"]:
             # Fetch information from symbol table


### PR DESCRIPTION
Closes #29.

Added support for sizeof operator. In simC instead of using sizeof used size operator.

**Implementation details**

1) Identified size as a keyword in lexical analyzer.
2) Added size to be parsed inside the expression while loop (this is done by adding the token name to OP_TOKENS in parser/parser_constants.py).
3) Parsed sizeof using call to `expression()`. 

**Test Case 1**

**simC Code**

```
MAIN
    var i = 5
    var b = size(i)
    print(b)
END_MAIN
```

**C Code**

```c
#include <stdio.h>

int main() {
	int i = 5;
	int b = sizeof(i);
	printf("%d", b);

	return 0;
}
```

All unit and code tests are passing, new tests to be added to accomodate sizeof operator. 