### PR TITLE
Add support for type statement

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -60,6 +60,7 @@ class LexicalAnalyzer:
             "true",
             "var",
             "size",
+            "type",
         ]
 
         self.c_unique_keywords = [

--- a/simc/parser/parser_constants.py
+++ b/simc/parser/parser_constants.py
@@ -45,6 +45,7 @@ OP_TOKENS = [
     "bool",
     "type_cast",
     "size",
+    "type",
 ]
 
 WORD_TO_OP = {

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -133,6 +133,27 @@ def expression(
             # sizeof returns int
             op_type = 3
 
+        # type operator - To find the type, compiles to a string
+        elif tokens[i].type == "type" and tokens[i + 1].type == "left_paren":
+            op_value, op_type, i, func_ret_type = expression(
+                tokens,
+                i + 1,
+                table,
+                "Expected expression inside size statement",
+                expect_paren=True,
+                break_at_last_closed_paren=True,
+                func_ret_type=func_ret_type,
+            )
+
+            type_to_prec = {3: "int", 4: "float", 5: "double"}
+            
+            # Convert the type of expression to string
+            op_value = op_value[:-len(op_value)]
+            op_value += "\"" + type_to_prec[op_type] + "\""
+
+            # Change the type of expression (the expression containing type statement) to string
+            op_type = 0
+
         # If token is identifier or constant
         elif tokens[i].type in ["number", "string", "id", "bool"]:
             # Fetch information from symbol table


### PR DESCRIPTION
Closes #31.

Added support for typeof. In simC instead of using sizeof used size operator. This just compiles to a string.

Implementation details

1) Identified type as a keyword in lexical analyzer.
2) Added type to be parsed inside the expression while loop (this is done by adding the token name to OP_TOKENS in parser/parser_constants.py).
3) Parsed sizeof using call to expression(). 
4) Converted the op_type returned to string and updated op_value, finally updated the expression's op_type to be 0 (char*).

**Test Case 1**

**simC Code**

MAIN
    var i = 0
    var b = type(i)
    print(b)
END_MAIN

**C Code**

```c
#include <stdio.h>

int main() {
	int i = 0;
	char* b = "int";
	printf("%s", b);

	return 0;
}
```

All unit and code tests are passing, new tests to be added to accommodate type.