### PR TITLE
Add flag 'scope_mapping' to mark the current scope(GLOBAL, FUN, MAIN,…

### DIFF
--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -871,9 +871,9 @@ def parse(tokens, table):
 
             # Exist cannot be called inside this scope
             if scope_mapping is SCOPE_STRUCT:
-                error("Exist cannot be called inside a struct scope", tokens[i].line_num)
+                error("Exit cannot be called inside a struct scope", tokens[i].line_num)
             elif scope_mapping is SCOPE_GLOBAL:
-                error("Exist cannot be called inside the global scope", tokens[i].line_num)
+                error("Exit cannot be called inside the global scope", tokens[i].line_num)
 
             exit_opcode, i, func_ret_type = exit_statement(
                 tokens, i + 1, table, func_ret_type

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -657,8 +657,6 @@ def parse(tokens, table):
                  # Struct cannot be called inside this scope
                 if scope_mapping is SCOPE_STRUCT:
                     error("Struct cannot be called inside a struct scope", tokens[i].line_num)
-                elif scope_mapping is SCOPE_GLOBAL:
-                    error("Struct cannot be called inside the global scope", tokens[i].line_num)
                 
                 # Get the details of id at index i - expected to be name of struct
                 struct_name, type_, _ = table.get_by_id(tokens[i].val)
@@ -804,7 +802,7 @@ def parse(tokens, table):
 
             # Do cannot be called inside this scope
             if scope_mapping is SCOPE_STRUCT:
-                error("Do cannot be called inside the struct scope", tokens[i].line_num)
+                error("Do cannot be called inside a struct scope", tokens[i].line_num)
             elif scope_mapping is SCOPE_GLOBAL:
                 error("Do cannot be called inside the global scope", tokens[i].line_num)
             


### PR DESCRIPTION
Closes #415

**Changes**
Until now, there was some variables being created to mark scope. To simplify this,  the variable **scope_mapping** will be charged on mark the scope, guided be some intuitive constants values.  

**Past variables**
struct_declared
single_funct_called

**New variables**
```
    # Mapping scopes
    SCOPE_GLOBAL = 0
    SCOPE_MAIN = 1
    SCOPE_FUNC = 2
    SCOPE_SINGLE_FUNC = 3
    SCOPE_STRUCT = 4

    # This is the state that indicate the actual scope
    scope_mapping = SCOPE_GLOBAL 
```

**Bugs solved**
1. No more code as loops and call functions are allowed in GLOBAL scope
2. No more declaration of structs and functions inside struct is allowed
3. One bug discover solved: More than a MAIN was allowed, if it closes before the next one begin. 
 
**Goal**
The code should be more clear 