### PR TITLE
Fixed ptr_only_assign bug by changing val's indices

### DIFF
--- a/simc/compiler.py
+++ b/simc/compiler.py
@@ -273,7 +273,7 @@ def compile(opcodes, c_filename, table):
         elif opcode.type == "ptr_only_assign":
             # val contains - <identifier>---<expression>---<count_ast>, split that into a list
             val = opcode.val.split("---")
-            code += "\t" + int(val[2]) * "*" + val[0] + " = " + val[1] + ";\n"
+            code += "\t" + int(val[3]) * "*" + val[0] + " = " + val[2] + ";\n"
 
         # If opcode is of type unary then generate an uanry statement
         elif opcode.type == "unary":


### PR DESCRIPTION
This PR is part of SWoC 2021
Closes #448 

Changed 276 of compiler.py to append the string named 'code' with the right values required.
Now, pointers can be assigned, and reassigned properly!