### PR TITLE
In-359 Acess variable of struct

### DIFF
--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -688,6 +688,11 @@ class LexicalAnalyzer:
                 self.tokens.append(Token("comma", "", self.line_num))
                 self.__update_source_index()
 
+             # Identifying point token
+            elif self.source_code[self.current_source_index] == ".":
+                self.tokens.append(Token("point", "", self.line_num))
+                self.__update_source_index()
+                
             # Identifying not_equal token
             elif (
                 self.source_code[self.current_source_index] == "!"

--- a/simc/lexical_analyzer.py
+++ b/simc/lexical_analyzer.py
@@ -687,11 +687,6 @@ class LexicalAnalyzer:
             elif self.source_code[self.current_source_index] == ",":
                 self.tokens.append(Token("comma", "", self.line_num))
                 self.__update_source_index()
-
-             # Identifying point token
-            elif self.source_code[self.current_source_index] == ".":
-                self.tokens.append(Token("point", "", self.line_num))
-                self.__update_source_index()
                 
             # Identifying not_equal token
             elif (

--- a/simc/parser/simc_parser.py
+++ b/simc/parser/simc_parser.py
@@ -650,7 +650,6 @@ def parse(tokens, table):
 
         # If token is of type id 
         elif tokens[i].type == "id":
-
             # If '(' follows id then it is function calling 
             if tokens[i + 1].type == "left_paren":
                 fun_opcode, i, func_ret_type = function_call_statement(
@@ -684,7 +683,7 @@ def parse(tokens, table):
                 if type_ != "struct_var":
                     error(f"Structure {struct_name} not declared", tokens[i].line_num)
 
-               # If there is no error then get the name of the instance variable
+                # If there is no error then get the name of the instance variable
                 instance_var_name, _, _, _ = table.get_by_id(tokens[i + 1].val)
   
                 # Init instance vars

--- a/simc/parser/struct_parser.py
+++ b/simc/parser/struct_parser.py
@@ -16,7 +16,7 @@ def initializate_struct(tokens, i, table, instance_var_name, var_list):
     """    
     # Initializate the child variable of struct
     var_ids = var_list.split('-')[1:]
-
+    
     # Load var and copy to struct initilization 
     for var_id in var_ids:
 

--- a/simc/parser/struct_parser.py
+++ b/simc/parser/struct_parser.py
@@ -2,6 +2,37 @@ from ..global_helpers import error, check_if
 
 from ..op_code import OpCode
 
+
+def initializate_struct(tokens, i, table, instance_var_name, var_list):
+    """
+        Initialization of a struction when the variable instantiate is type of a declared struct
+        Params
+        ======
+        tokens      (list) = List of tokens
+        i           (int)  = Current index in token
+        table               (SymbolTable) = Symbol Table constructed holding information about identifiers and constans
+        instance_var_name   (String)      = Name of the instance of the struct
+        var_list            (String)      = List of if variable declared inside struct
+    """    
+    # Initializate the child variable of struct
+    var_ids = var_list.split('-')[1:]
+
+    # Load var and copy to struct initilization 
+    for var_id in var_ids:
+
+        # Find the child variable of struct 
+        var_name, type_, metatype_, _ = table.get_by_id(int(var_id))
+        new_var_name = instance_var_name + "." + var_name
+
+        # Check if variable already exist
+        new_var_id = table.get_by_symbol(new_var_name)
+        # If it not exist, then create a new
+        if new_var_id is -1:
+            table.entry(instance_var_name + "." + var_name, type_, metatype_, '')
+        # Otherwise, Modify datatype of the identifier
+        else:
+            table.symbol_table[new_var_id][1] = type_
+
 def struct_declaration_statement(tokens, i, table):
     """
     Parse structure declaration statement

--- a/simc/parser/struct_parser.py
+++ b/simc/parser/struct_parser.py
@@ -32,6 +32,7 @@ def initializate_struct(tokens, i, table, instance_var_name, var_list):
         # Otherwise, Modify datatype of the identifier
         else:
             table.symbol_table[new_var_id][1] = type_
+            table.symbol_table[new_var_id][3] += '-' + var_id
 
 def struct_declaration_statement(tokens, i, table):
     """

--- a/simc/parser/variable_parser.py
+++ b/simc/parser/variable_parser.py
@@ -341,7 +341,7 @@ def assign_statement(tokens, i, table, func_ret_type):
 
     # Store the id of variable in Symbol Table
     var_id = tokens[id_idx].val
-
+    
     # Check if is a array indexing case
     if tokens[i].type == "left_bracket":
         if(tokens[i + 1].type == "number"):

--- a/simc/symbol_table.py
+++ b/simc/symbol_table.py
@@ -121,6 +121,8 @@ class SymbolTable:
 
             # If the type is not defined
             if child_type is "declared":
+                if type_ == "string":
+                    type_ = "char*"
                 self.symbol_table[var_child_id][1] = type_
                 is_allowed = self.resolve_dependency(tokens, i, var_child_id)
 


### PR DESCRIPTION
Closes #359 

**Implementation details**
Add lexical operator; for each variable declared inside the struct, will be a copy saved for the struct var name in SymbolTable, example:

```
struct test {
      var a 
} one, two
```

SymbolTable:

```
one.a, 'var', 'variable', '-1'
two.a, 'var', 'variable', '-1'
```

The 1 is the id of variable inside struct, it's used to verify the primary type declared. 

**Test Case 1**

**simC Code**
```
struct test {
	var a = 3
}one

fun test_param(b) {
	return b
}

MAIN
	print(one.a)
	test_param(one.a)
END_MAIN
````

**C Code (If generated)**
```
struct test {
	int a;
} one;

int test_param(int b) {

	return b;
}

int main() {
	one.a = 3;
	printf("%d", one.a);
	test_param(one.a);

	return 0;
}
```


**Test Case 2**

**simC Code**
```
struct test {
	var b
}one

MAIN
	test unchanged

	unchanged.b = 3.4 // auto casting
END_MAIN

```

**C Code (If generated)**
struct test {
	float b;
} one;

int main() {
	struct test unchanged;
	unchanged.b = 3.4;
	//  auto casting 

	return 0;
}


**Test Case 3**

**simC Code**
```
struct test {
	var a
	var b = 1
}one

MAIN
	test two 
	one.a = 'a'
	one.b = 2
	two.a = 'b'
	two.b = 1
	
END_MAIN

```
**C Code (If generated)**
```
struct test {
	char a;
	int b = 1;
} one;

int main() {
	struct test two;
	one.a = 'a';
	one.b = 2;
	two.a = 'b';
	two.b = 1;

	return 0;
}
```


Number of unit tests passing: [ 272/273]
Number of code tests passing: [ 106/106]
