### PR TITLE
Fix: error message for when function is not declared

### DIFF
--- a/simc/parser/function_parser.py
+++ b/simc/parser/function_parser.py
@@ -30,6 +30,9 @@ def function_call_statement(tokens, i, table, func_ret_type):
     func_name = func_info[0]
     metadata = func_info[2]
 
+    if metadata == "variable":
+        error(f"No definition found for function {func_name}", tokens[i].line_num)
+
     # Get all parameter ids (default and non-default) and the default values (if any)
     params, default_values = extract_func_typedata(metadata, table)
     num_formal_params = len(params)


### PR DESCRIPTION
Closes #437 

**Implementation details**
In function_call_statement (simc/parser/function_parser.py) check if function metadata is of the form <func-name>---[<params>]+ or not, if function is not defined then this field will have value "variable". If the value is variable then throw error message.

**Test Case 1**

**simC Code**
```python
MAIN
    sum(1, 2)
END_MAIN
```

**C Code (If generated)**

**Error message (If any)**
```bash
[Line 2] Error: No definition found for function sum
```

Number of unit tests passing: [273 / 273]
Number of code tests passing: [160 / 160]
