### PR TITLE
Fix extra comma issue in array initializer

### DIFF
--- a/simc/parser/array_parser.py
+++ b/simc/parser/array_parser.py
@@ -115,6 +115,12 @@ def array_initializer(tokens, i, table, size_of_array, msg, func_ret_type):
             )
             op_value += op_value_temp
 
+            # If after splitting by comma there are more than one empty field then throw error
+            # One is allowed since there can be one comma at the end like - {1, 2, }
+            split_by_comma = op_value_temp.split(",")
+            if split_by_comma.count('') > 1:
+                error("Too many commas at the end of initializer list", line_num=tokens[i].line_num)
+
             # If the size of the array is defined, and if the number of tokens parsed is not equal to
             # what it should be, then display error
             if (


### PR DESCRIPTION
Closes #469

**Implementation details**
When the expression inside the { } is parsed in array_initializer (simc/parser/array_parser.py), the resulting op_value contains the entire value till }. The resulting string can be split on , and if the list contains more than one empty string ("") then it means that there are more than one comma at the end of the initializer at which point we can safely throw an error. 

**Test Case 1**

**simC Code**
```python
MAIN
    var a[] = {1, 2, , , }
END_MAIN
```

**C Code (If generated)**
Not generated, error thrown.

**Error message (If any)**
```bash
[Line 2] Error: Too many commas at the end of initializer list
```
Number of unit tests passing: [273 / 273]
Number of code tests passing: [160 / 160]
